### PR TITLE
Poll result images are missing

### DIFF
--- a/src/main/java/de/maikmerten/bbbdownload/downloader/Downloader.java
+++ b/src/main/java/de/maikmerten/bbbdownload/downloader/Downloader.java
@@ -87,6 +87,14 @@ public class Downloader {
             slide_resources.add(text);
         }
 
+        // find all poll_result SVGs referenced in shapes.svg
+        Pattern poll_result_pattern = Pattern.compile("presentation/\\p{Alnum}{40}-\\d{13}/poll_result[0-9]+\\.svg");
+        m = poll_result_pattern.matcher(shapestring);
+        while (m.find()) {
+            String poll_result = m.group();
+            slide_resources.add(poll_result);
+        }
+
         for (String resource : slide_resources) {
             downloadIntoZip(baseURL + "/presentation/" + recId + "/" + resource, resource, zos);
         }


### PR DESCRIPTION
Poll result images are referenced in shapes.svg. Added to find them in shapes.svg, download and zip these slide_resources too.